### PR TITLE
Lesson 22: Tournament Viewer - Part 1

### DIFF
--- a/TrackerLibrary/Models/MatchupModel.cs
+++ b/TrackerLibrary/Models/MatchupModel.cs
@@ -31,5 +31,34 @@ namespace TrackerLibrary.Models
         /// Represents the Round in which the matchup is taking place.
         /// </summary>
         public int MatchupRound { get; set; }
+
+        public string DisplayName
+        {
+            get
+            {
+                string output = "";
+
+                foreach (MatchupEntryModel me in Entries)
+                {
+                    if (me.TeamCompeting != null)
+                    {
+                        if (output.Length == 0)
+                        {
+                            output = me.TeamCompeting.TeamName;
+                        }
+                        else
+                        {
+                            output += $" vs. {me.TeamCompeting.TeamName}";
+                        }
+                    }
+                    else
+                    {
+                        output = "Matchup not yet determined.";
+                        break;
+                    }
+                }
+                return output;
+            }
+        }
     }
 }

--- a/TrackerUI/TournamentDashboardWindow.xaml
+++ b/TrackerUI/TournamentDashboardWindow.xaml
@@ -38,9 +38,20 @@
             </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>        
-        <Button Grid.Row="5" x:Name="LoadTournamentButton" Content="Load Tournament" HorizontalAlignment="Center" VerticalAlignment="Center" Height="50" Width="200" FontSize="20"/>
+        <Button Grid.Row="5" x:Name="LoadTournamentButton" Content="Load Tournament" HorizontalAlignment="Center" VerticalAlignment="Center" Height="50" Width="200" FontSize="20" Click="LoadTournamentButton_Click"/>
 
-        <Button Grid.Row="7" x:Name="CreateTournamentButton" Content="Create Tournament" HorizontalAlignment="Center" VerticalAlignment="Center" Height="75" Width="300" FontSize="24" Background="#FF80D1FF" BorderBrush="#FF00A3FF" FontWeight="Bold" Foreground="#FF2E2E2E"/>
+        <Button Grid.Row="7" 
+                x:Name="CreateTournamentButton" 
+                Content="Create Tournament" 
+                HorizontalAlignment="Center" 
+                VerticalAlignment="Center" 
+                Height="75" 
+                Width="300" 
+                FontSize="24" 
+                Background="#FF80D1FF" 
+                BorderBrush="#FF00A3FF" 
+                FontWeight="Bold" 
+                Foreground="#FF2E2E2E" Click="CreateTournamentButton_Click"/>
 
     </Grid>
 </Window>

--- a/TrackerUI/TournamentDashboardWindow.xaml.cs
+++ b/TrackerUI/TournamentDashboardWindow.xaml.cs
@@ -47,5 +47,19 @@ namespace TrackerUI
             LoadExistingTournamentDropdown.ItemsSource = tournaments;
         }
 
+        private void CreateTournamentButton_Click(object sender, RoutedEventArgs e)
+        {
+            CreateTournamentWindow frm = new CreateTournamentWindow();
+            frm.Show();
+        }
+
+        private void LoadTournamentButton_Click(object sender, RoutedEventArgs e)
+        {
+            TournamentModel tm = (TournamentModel)LoadExistingTournamentDropdown.SelectedItem;
+
+            TournamentViewerWindow frm = new TournamentViewerWindow(tm);
+
+            frm.Show();
+        }
     }
 }

--- a/TrackerUI/TournamentViewerWindow.xaml
+++ b/TrackerUI/TournamentViewerWindow.xaml
@@ -1,9 +1,10 @@
-﻿<Window x:Class="TrackerUI.TournamentViewerWindow"
+﻿<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:TrackerUI"
+        xmlns:Models="clr-namespace:TrackerLibrary.Models;assembly=TrackerLibrary" x:Class="TrackerUI.TournamentViewerWindow"
         mc:Ignorable="d"
         ResizeMode="CanMinimize"
         Title="Tournament Viewer" Height="500" Width="750" Background="#FF2E2E2E" FontSize="16" Icon="/iconfinder_icon-clipboard_211649.png">
@@ -33,23 +34,51 @@
         <Label  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="3" Margin="-70,10,0,0" x:Name="TournamentNameLabel" Content="'None'" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="White" FontSize="28" Height="auto" Width="auto"/>
 
         <Label Grid.Row="2" Grid.Column="0" Margin="20,0,0,0" x:Name="RoundLabel" Content="Round" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="White" FontSize="20" Height="auto" Width="auto"/>
-        <ComboBox Grid.Row="2" Grid.Column="0" x:Name="RoundDropdown" HorizontalAlignment="Right" VerticalAlignment="Top" Width="160" FontSize="20"/>
+
+        <ComboBox 
+            x:Name="RoundDropdown" 
+            ItemsSource="{Binding rounds}"
+            Grid.Row="2" 
+            Grid.Column="0"            
+            HorizontalAlignment="Right" 
+            VerticalAlignment="Top" 
+            Width="160" 
+            FontSize="20"
+            SelectedIndex="0"
+            SelectionChanged="RoundDropdown_SelectionChanged" 
+            >
+        </ComboBox>
+
         <CheckBox  Grid.Row="3" Grid.Column="0" x:Name="UnplayedOnlyCheckbox" Content="Unplayed Only" HorizontalAlignment="Right" VerticalAlignment="Top" Foreground="White" Height="auto" Width="auto" UseLayoutRounding="False" VerticalContentAlignment="Center"/>
 
-        <ListBox Grid.Row="5" Grid.Column="0" Grid.RowSpan="6" Margin="20,0,0,0" x:Name="MatchupListbox"></ListBox>
+        <ListBox 
+            x:Name="MatchupListbox"             
+            ItemsSource="{Binding MatchupModel}"
+            Grid.Row="5" 
+            Grid.Column="0" 
+            Grid.RowSpan="6" 
+            Margin="20,0,0,0" SelectionChanged="MatchupListbox_SelectionChanged" >
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding DisplayName}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
 
-        <Label Grid.Row="5" Grid.Column="2" x:Name="TeamOneNameLabel" Content="Team One" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="White" FontSize="20" Height="auto" Width="auto"/>
+        <Label Grid.Row="4" Grid.Column="2" x:Name="TeamOneNameLabel" Content="Team One" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="White" FontSize="20" Height="auto" Width="300" Grid.ColumnSpan="2" Margin="0,21,0,0" Grid.RowSpan="2"/>
         <Label Grid.Row="6" Grid.Column="2"  x:Name="TeamOneScoreLabel" Content="Score:" HorizontalAlignment="Left" VerticalAlignment="Center" Foreground="White" FontSize="20" Height="auto" Width="auto"/>
         <TextBox Grid.Row="6" Grid.Column="2" Margin="0,0,40,0" x:Name="TeamOneScoreValueTextBox" HorizontalAlignment="Right" Text="" TextWrapping="Wrap" VerticalAlignment="Center" Height="auto" Width="70" FontSize="20"/>
 
         <Label Grid.Row="7" Grid.Column="2" Grid.RowSpan="2" Margin="0,0,40,0" x:Name="VersusLabel" Content="-- VS --" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="#BFFFFFFF" FontSize="20" FontStyle="Italic"/>
 
-        <Label Grid.Row="9" Grid.Column="2" x:Name="TeamTwoNameLabel" Content="Team Two" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="White" FontSize="20" FontStyle="Normal"/>
+        <Label Grid.Row="9" Grid.Column="2" x:Name="TeamTwoNameLabel" Content="Team Two" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="White" FontSize="20" FontStyle="Normal" Grid.ColumnSpan="2" Width="300"/>
         <Label Grid.Row="10" Grid.Column="2" x:Name="TeamTwoScoreLabel" Content="Score:" HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="White" FontSize="20" />
         <TextBox Grid.Row="10" Grid.Column="2" Margin="0,0,40,0" x:Name="TeamTwoScoreValueTextBox" HorizontalAlignment="Right" TextWrapping="Wrap" VerticalAlignment="Center" Width="70" FontSize="20"/>
 
-        <Button Grid.Row="7" Grid.Column="3" Grid.RowSpan="2" x:Name="FinishMatchButton" Content="Finish Match" HorizontalAlignment="Left" VerticalAlignment="Center" Width="120" Height="50" Background="#FF80D1FF" BorderBrush="#FF00A3FF" FontWeight="Bold" Foreground="#FF2E2E2E"/>
+        <Button Grid.Row="7" Grid.Column="3" Grid.RowSpan="2" x:Name="ScoreButton" Content="Score" HorizontalAlignment="Left" VerticalAlignment="Center" Width="120" Height="50" Background="#FF80D1FF" BorderBrush="#FF00A3FF" FontWeight="Bold" Foreground="#FF2E2E2E"/>
     </Grid>
 
 
 </Window>
+
+    

--- a/TrackerUI/TournamentViewerWindow.xaml.cs
+++ b/TrackerUI/TournamentViewerWindow.xaml.cs
@@ -12,6 +12,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using TrackerLibrary.Models;
 
 namespace TrackerUI
 {
@@ -20,9 +21,138 @@ namespace TrackerUI
     /// </summary>
     public partial class TournamentViewerWindow : Window
     {
-        public TournamentViewerWindow()
+        private TournamentModel tournament;
+        List<int> rounds = new List<int>();
+        List<MatchupModel> selectedMatchups = new List<MatchupModel>();
+
+        public TournamentViewerWindow(TournamentModel tournamentModel)
         {
             InitializeComponent();
+            tournament = tournamentModel;
+            LoadRounds();
+            LoadFormData();
+            WireUpRoundsLists();
+        }
+
+        private void LoadFormData()
+        {
+            // Set the Tournament Name Label as the selected Tournament's name.
+            TournamentNameLabel.Content = tournament.TournamentName;
+        }
+
+        private void WireUpRoundsLists()
+        {
+            // Wire up the RoundDropDown combobox.
+            RoundDropdown.ItemsSource = null;
+            RoundDropdown.ItemsSource = rounds;
+        }
+
+        private void WireUpMatchupList()
+        {
+            // Wire up the MatchupListbox.
+            MatchupListbox.ItemsSource = null;
+            MatchupListbox.ItemsSource = selectedMatchups;
+
+            // Whenever you select a round, a matchup should be selected, however if one isn't then the Team 1 and Team 2
+            // names will be displayed as "No matchup selected" (prevents them from showing any previously selected matchup team names).
+            if (MatchupListbox.SelectedItem == null)
+            {
+                TeamOneNameLabel.Content = "No matchup selected";
+                TeamTwoNameLabel.Content = "No matchup selected";
+            }
+        }
+
+        private void LoadRounds()
+        {
+            rounds = new List<int>();
+            rounds.Add(1);
+            int currRound = 1;
+
+            foreach (List<MatchupModel> matchups in tournament.Rounds)
+            {
+                if (matchups.First().MatchupRound > currRound)
+                {
+                    currRound = matchups.First().MatchupRound;
+                    rounds.Add(currRound);
+                }
+            }
+
+            LoadMatchups(1);
+        }
+
+        private void RoundDropdown_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (RoundDropdown.SelectedItem == null)
+            {
+                RoundDropdown.SelectedIndex = 0;
+            }
+            else
+            {
+                LoadMatchups((int)RoundDropdown.SelectedItem);
+            }
+            WireUpMatchupList();
+        }
+
+        private void LoadMatchups(int round)
+        {
+            foreach (List<MatchupModel> matchups in tournament.Rounds)
+            {
+                if (matchups.First().MatchupRound == round)
+                {
+                    selectedMatchups = matchups;
+                }
+            }
+
+            LoadMatchup(selectedMatchups.First());
+        }
+
+        private void LoadMatchup(MatchupModel m)
+        {
+            for (int i = 0; i < m.Entries.Count; i++)
+            {
+                if (i == 0)
+                {
+                    if (m.Entries[0].TeamCompeting != null)
+                    {
+                        TeamOneNameLabel.Content = m.Entries[0].TeamCompeting.TeamName;
+                        TeamOneScoreValueTextBox.Text = m.Entries[0].Score.ToString();
+
+                        TeamTwoNameLabel.Content = "<BYE>";
+                        TeamTwoScoreValueTextBox.Text = "0";
+                    }
+                    else
+                    {
+                        TeamOneNameLabel.Content = "Not yet set";
+                        TeamOneScoreValueTextBox.Text = "";
+                    }
+                }
+
+                if (i == 1)
+                {
+                    if (m.Entries[1].TeamCompeting != null)
+                    {
+                        TeamTwoNameLabel.Content = m.Entries[1].TeamCompeting.TeamName;
+                        TeamTwoScoreValueTextBox.Text = m.Entries[1].Score.ToString();
+                    }
+                    else
+                    {
+                        TeamTwoNameLabel.Content = "Not yet set";
+                        TeamTwoScoreValueTextBox.Text = "";
+                    }
+                }
+            }
+        }
+
+        private void MatchupListbox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (MatchupListbox.SelectedItem == null)
+            {
+                MatchupListbox.SelectedIndex = 0;
+            }
+            else
+            {
+                LoadMatchup((MatchupModel)MatchupListbox.SelectedItem);
+            }
         }
     }
 }


### PR DESCRIPTION
### **Lesson 22: Tournament Viewer - Part 1**

Wiring up items in the Tournament View Window.

* TournamentNameLabel is populated with the name of the selected Tournament (passed in from the TournamentDashboardWindow).
* RoundsDropdown combobox fully wired up and changes the MatchupsListbox depending on item selected.
* MatchupsListbox fully wired up to display matchups between teams.
* TeamOneNameLabel now updates to first team in matchup when you select a matchup in the MatchupsListbox.
* TeamTwoNameLabel now updates to first team in matchup when you select a matchup in the MatchupsListbox.